### PR TITLE
feat(ext): enable opcache,gmp,sodium,xsl ext

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -16,6 +16,7 @@ install_php() {
   echo "Determining configuration options..."
   local source_path=$(get_download_file_path $install_type $version $tmp_download_dir)
   local configure_options="$(construct_configure_options $install_path)"
+  local configure_options="$(construct_configure_options $install_path $version)"
   local make_flags="-j$ASDF_CONCURRENCY"
 
   local operating_system=$(uname -a)
@@ -111,6 +112,7 @@ install_composer() {
 
 construct_configure_options() {
   local install_path=$1
+  local version=$2
 
   # many options included below are not applicable to newer PHP versions
   # including these will trigger a build warning, but will not b
@@ -149,6 +151,7 @@ construct_configure_options() {
     --with-mysqli=mysqlnd \
     --with-pdo-mysql=mysqlnd \
     --with-xmlrpc \
+    --with-xsl \
     --with-zip \
     --with-zlib \
     --without-snmp"
@@ -189,6 +192,12 @@ construct_configure_options() {
     configure_options="$configure_options"
   else
     configure_options="$configure_options --without-pcre-jit"
+  fi
+
+  $version_builtin_opcache = "5.5.0"
+
+  if [ $(echo "$version,$version_builtin_opcache" | tr "," "\n" | sort -V -r | head -1) == "$version"]; then
+    $configure_options="$configure_options --with-opcache"
   fi
 
   echo "$configure_options"
@@ -342,6 +351,8 @@ os_based_configure_options() {
   else
     local jpeg_path=$(locate libjpeg.so | awk '{ print length(), $0 | "sort -n" }' | cut -d" " -f2- | head -n 1)
     local libpng_path=$(locate libpng.so | awk '{ print length(), $0 | "sort -n" }' | cut -d" " -f2- | head -n 1)
+    local libgmp_path=$(locate libgmp.so | awk '{ print length(), $0 | "sort -n" }' | cut -d" " -f2- | head -n 1)
+    local libsodium_path=$(locate libsodium.so | awk '{ print length(), $0 | "sort -n" }' | cut -d" " -f2- | head -n 1)
     configure_options="--with-openssl --with-curl --with-zlib --with-readline --with-gettext"
 
     if [ "$jpeg_path" = "" ]; then
@@ -354,6 +365,18 @@ os_based_configure_options() {
       export ASDF_PKG_MISSING="$ASDF_PKG_MISSING libpng"
     else
       configure_options="$configure_options --with-png-dir=$libpng_path --with-png"
+    fi
+
+    if [ "$libgmp_path" = "" ]; then
+      export ASDF_PKG_MISSING="$ASDF_PKG_MISSING gmp"
+    else
+      configure_options="--with-gmp=$libgmp_path"
+    fi
+
+    if [ "$libsodium_path" = "" ]; then
+      export ASDF_PKG_MISSING="$ASDF_PKG_MISSING sodium"
+    else
+      configure_options="$configure_options --with-sodium=$libsodium_path"
     fi
   fi
 


### PR DESCRIPTION
- enable opcache extension by default with min php ver > 5.5.0
- enable gmp and sodium extensions if those libs exists in linux machine
- enable xsl extension by default